### PR TITLE
Add user name fields to TicketPublic schema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -61,7 +61,8 @@ class Ticket(TicketBase):
 
 
 class TicketPublic(Ticket):
-    pass
+    assigned_to_name: str | None
+    author_name: str
 
 
 class TicketUpdate(TicketBase):


### PR DESCRIPTION
## Summary
- Added `assigned_to_name` and `author_name` fields to `TicketPublic` schema to provide human-readable names for better ticket display

## Test plan
- Verify schema changes don't break existing API endpoints
- Test that new fields are properly populated when tickets are returned

🤖 Generated with [Claude Code](https://claude.ai/code)